### PR TITLE
Initially hide status bar

### DIFF
--- a/MyRWTutorial/Info.plist
+++ b/MyRWTutorial/Info.plist
@@ -28,6 +28,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Just a small tweak but I noticed over my last few tech edits that a dark status bar appears over the launch screen and it looks ugly. I could have either switched to using the light style initially or just hide it on launch and I decided that hiding it until the app starts looks better. 


Before|After
---|---
<img width="187.5" alt="before" src="https://user-images.githubusercontent.com/482871/47965347-eab29880-e03d-11e8-8dc0-3e4090b0a946.png">|<img width="187.5" alt="after" src="https://user-images.githubusercontent.com/482871/47965348-eab29880-e03d-11e8-9232-384bd1c18981.png">



Let me know what you think