### PR TITLE
Update Info.plist in UIKit and SwiftUI projects to set `UIStatusBarHidden` to `YES` 

### DIFF
--- a/SwiftUI/MyRWTutorial/Info.plist
+++ b/SwiftUI/MyRWTutorial/Info.plist
@@ -18,6 +18,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/UIKit/MyRWTutorial/Info.plist
+++ b/UIKit/MyRWTutorial/Info.plist
@@ -18,6 +18,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
This one bugs me each time I do a TE so I thought that I should probably submit it here 😄 

With the nice launch screen, it looks a bit odd having the dark status bar barely visible over the dark graphic. I tried setting it to the white status bar instead but that doesn't look much better either so personally I prefer just hiding it.

Before|After
---|---
<img width="547" alt="before" src="https://user-images.githubusercontent.com/482871/118399068-a87d5f80-b65b-11eb-8768-38c2f07bd228.png">|<img width="547" alt="after" src="https://user-images.githubusercontent.com/482871/118399067-a5826f00-b65b-11eb-9133-ced5cb2b757b.png">


cc @rcritz 